### PR TITLE
Use refinements to avoid polluting number classes globally

### DIFF
--- a/lib/waitforit.rb
+++ b/lib/waitforit.rb
@@ -1,38 +1,42 @@
-module TimeIncrements
-  def seconds
-    self * 1
+module Waitforit
+  module TimeIncrements
+    [Float, Fixnum].each do |numeric_class|
+      refine numeric_class do
+        def seconds
+          self * 1
+        end
+
+        def minutes
+          seconds * 60
+        end
+
+        def hours
+          minutes * 60
+        end
+
+        def days
+          hours * 24
+        end
+
+        alias_method :second, :seconds
+        alias_method :minute, :minutes
+        alias_method :hour, :hours
+        alias_method :day, :days
+      end
+    end
   end
-  
-  def minutes
-    seconds * 60
-  end
-  
-  def hours
-    minutes * 60
-  end
-  
-  def days
-    hours * 24
-  end
-  
-  alias_method :second, :seconds
-  alias_method :minute, :minutes
-  alias_method :hour, :hours
-  alias_method :day, :days
-end
-class Float
-  include TimeIncrements
-end
-class Fixnum 
-  include TimeIncrements
 end
 
-def wait_until opts={}
-  opts = {:timeout_after => 5.seconds,:retry_every => 0.1.seconds}.merge(opts)
-  start_time = Time.now
-  until Time.now > start_time + opts[:timeout_after]
-    return true if yield == true
-    sleep opts[:retry_every]
+module Kernel
+  using ::Waitforit::TimeIncrements
+
+  def wait_until opts={}
+    opts = {:timeout_after => 5.seconds,:retry_every => 0.1.seconds}.merge(opts)
+    start_time = Time.now
+    until Time.now > start_time + opts[:timeout_after]
+      return true if yield == true
+      sleep opts[:retry_every]
+    end
+    raise RuntimeError, "Action took to long"
   end
-  raise RuntimeError, "Action took to long"
 end

--- a/spec/waitforit_spec.rb
+++ b/spec/waitforit_spec.rb
@@ -2,6 +2,8 @@ require 'rspec'
 require "#{File.dirname(__FILE__)}/../lib/waitforit"
 
 describe 'waitforit' do
+  using ::Waitforit::TimeIncrements
+
   it 'should wait until the prescribed thing has happened' do
     end_time = Time.now + 1
     wait_until do
@@ -34,7 +36,7 @@ describe 'waitforit' do
       count.should == 2
     end
   end
-  
+
   it 'should be able to nest wait_until statements' do
     wait_until{wait_until{true}}
   end


### PR DESCRIPTION
Hi @lashd.

Time increments usually come with `activesupport` on many projects. When a project has `waitforit` along with `activesupport`, then the methods from waitforit take precedence since activesupport only declares methods like `seconds` or `hours` if they do not already exist. Also `activesupport`'s versions of these methods return instances of `ActiveSupport::Duration` and not numeric classes like `Fixnum`.

Active support also comes with support for methods like `ago` and `from_now` that are used commonly to represent time instances in a readable notation like `5.days.ago`. When used with `waitforit` this starts throwing deprecation warnings for the `#ago` method since these are meant to be called on `ActiveSupport::Duration` objects and not `Fixnums`. 
`#ago` notation is a very common pattern in rails and, thus, the monkeypatch in this gem leads to a ton of deprecation warning as soon as you start using Mirage in any rails project. 

This PR proposes using Ruby's refinements instead. That way, the time increments can be used only in places that want to use these specific refinements. Example usage can be found at [lib/waitforit.rb#L31](https://github.com/lashd/waitforit/blob/ef60aca64cfc803fad51c83abe25d446bc7770f9/lib/waitforit.rb#L31)

Downside is that it will work only on ruby 2.0 and above. Earlier versions of ruby are no longer supported by ruby maintainers, so this should be ok to use.
